### PR TITLE
Adding Logout of Spotify functionality and additional states for login

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,12 +4,14 @@ import './App.css';
 
 class App extends Component {
 state = {
-    data: null
+    data: null,
+    loggedIn: false,
+    username: "Not Logged In"
   };
 
   componentDidMount() {
     this.callBackendAPI()
-      .then(res => this.setState({ data: res.express }))
+      .then(res => this.setState({ data: res.express, loggedIn: res.login, username: res.name}))
       .catch(err => console.log(err));
   }
     // fetching the GET route from the Express server which matches the GET route from server.js
@@ -27,14 +29,36 @@ state = {
     window.location.href = 'http://localhost:8000/loginSpotify';
   }
 
+  logoutSpotify() {
+      window.location.href = 'http://localhost:8000/logout'
+
+      /*const url = 'https://www.spotify.com/logout/'
+      let left = (screen.width/2)-(700/2);
+      let top = (screen.height/2)-(700/2);
+      const spotifyLogoutWindow = window.open(url, 'Spotify Logout', 'width=700,height=700,top='+top+',left='+left);
+      setTimeout(() => spotifyLogoutWindow.close(), 2000);*/
+   }
+
   render() {
+    const isLoggedIn = this.state.loggedIn;
+    let button;
+    if (!isLoggedIn) {
+        button = <button onClick={this.loginSpotify}>Login to Spotify</button>;
+    } else {
+        button = <button onClick={this.logoutSpotify}>Logout of Spotify</button>;
+    }
+
     return (
       <div className="App">
         <header className="App-header">
           <h1 className="App-title">Youtube To Spotify</h1>
+          <p className="App-intro">{this.state.username}</p>
+          <div>
+            <p>{button}</p>
+           </div>
         </header>
-        <p className="App-intro">{this.state.data}</p>
-        <button onClick={this.loginSpotify}>Login to Spotify</button>
+
+
       </div>
     );
   }

--- a/server.js
+++ b/server.js
@@ -21,7 +21,8 @@ app.use(
 
 app.use("/loginSpotify", require("./server/routes/loginSpotify"));
 app.use("/callback", require("./server/routes/callbackSpotify"));
-app.use("/express_backend", require("./server/routes/home"))
+app.use("/express_backend", require("./server/routes/home"));
+app.use("/logout", require("./server/routes/logout"));
 
 
 

--- a/server/config.js
+++ b/server/config.js
@@ -9,6 +9,7 @@ module.exports = {
   state: "",
   access_token: "",
   refresh_token: "",
+  loggedOut: false,
 
   googleClientID: "919300781767-so4aua5uc2pn71s6ja3l5gusf7rnehgm.apps.googleusercontent.com",
   googleClientSecret: "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",

--- a/server/routes/callbackSpotify.js
+++ b/server/routes/callbackSpotify.js
@@ -36,6 +36,7 @@ router.get("/", (req, res) => {
            if (!error && response.statusCode === 200) {
              config.access_token = body.access_token;
              config.refresh_token = body.refresh_token;
+             config.loggedOut = false;
              res.redirect(`http://localhost:${config.clientPort}`);
              console.log("Successfully logged into Spotify");
            } else {

--- a/server/routes/home.js
+++ b/server/routes/home.js
@@ -6,7 +6,14 @@ const config = require('../config');
 router.get('/', (req, res) => {
   let BASE_URL = 'https://api.spotify.com/v1/';
   let headers = {'Authorization': 'Bearer ' + config.access_token}
-  if (config.access_token != "") {
+  if (config.loggedOut == true) {
+    console.log("logged out");
+    res.send({
+        login : false,
+        name : "Not Logged In"
+    })
+  }
+  else if (config.access_token != "") {
     request(
       {
         method: "GET",
@@ -20,13 +27,15 @@ router.get('/', (req, res) => {
           console.log(body['display_name']);
           res.send(
             {
-              express : body['display_name']
+              login : true,
+              name : body['display_name']
             });
         } else {
           console.log("Error fetching profile");
         }
     });
   }
+
 
   let GOOGLE_BASE_URL = 'https://www.googleapis.com/youtube/v3/';
   let google_headers = {'Authorization': 'Bearer ' + config.google_access_token};

--- a/server/routes/logout.js
+++ b/server/routes/logout.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const request = require("request");
+const config = require("../config");
+const cors = require("cors");
+const querystring = require("querystring");
+const cookieParser = require("cookie-parser");
+
+ router.get("/", (req, res) => {
+    config.loggedOut = true;
+    res.redirect(`http://localhost:${config.clientPort}`);
+ });
+
+module.exports = router;


### PR DESCRIPTION
Button changes based on whether the user is logged in or logged out.

Username will display either as "Not Logged in" or your Spotify username.

Reorganized frontend so the name and button are displayed on the main screen rather than below it.

TODO:
- make sure logout.js also calls req.session.destroy(), clears cookies, and resets config
- Add additional stuff from spotify API
- Do the same exact process for Youtube.